### PR TITLE
use Array.isArray, isObject from lodash, Buffer.isBuffer

### DIFF
--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -1,6 +1,8 @@
+import { isObject } from 'lodash'
+
 export class TypeUtils {
     static isObject(value: any): boolean {
-        return value && typeof value === 'object' && value.constructor === Object
+        return isObject(value)
     }
 
     static isArray(value: any): boolean {
@@ -8,6 +10,6 @@ export class TypeUtils {
     }
 
     static isBuffer(value: any): boolean {
-        return value && (value.type === 'Buffer' || Buffer.isBuffer(value))
+        return Buffer.isBuffer(value)
     }
 }


### PR DESCRIPTION
[Array.isArray exists more than 10 years.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
![Screenshot 2024-03-13 at 21 12 49](https://github.com/diia-open-source/be-pkg-utils/assets/8398353/3b7ee1af-1fe5-4a4d-bc93-3d3351b63b23)
There is no need to use `value && typeof value === 'object' && value.constructor === Array`